### PR TITLE
Fix for releasing to melpa.org

### DIFF
--- a/helm-elscreen.el
+++ b/helm-elscreen.el
@@ -15,6 +15,10 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+;;
+;; helm-elscreen is a Helm interface for Elscreen.
+
 ;;; Code:
 (require 'cl-lib)
 (require 'helm)
@@ -25,7 +29,8 @@
 (declare-function elscreen-get-conf-list "ext:elscreen.el" (type))
 
 (defun helm-find-buffer-on-elscreen (candidate)
-  "Open buffer in new screen, if marked buffers open all in elscreens."
+  "Open CANDIDATE buffer in new elscreen.
+If marked buffers, open all in elscreens."
   (helm-require-or-error 'elscreen 'helm-find-buffer-on-elscreen)
   (helm-aif (helm-marked-candidates)
       (cl-dolist (i it)
@@ -37,6 +42,8 @@
       (elscreen-goto target-screen))))
 
 (defun helm-elscreen-find-file (file)
+  "Switch to a elscreen visiting FILE.
+If none already exists, creating one."
   (helm-require-or-error 'elscreen 'helm-elscreen-find-file)
   (elscreen-find-file file))
 

--- a/helm-elscreen.el
+++ b/helm-elscreen.el
@@ -1,6 +1,12 @@
-;;; helm-elscreen.el -- Elscreen support -*- lexical-binding: t -*-
+;;; helm-elscreen.el --- Elscreen support -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012 ~ 2017 Thierry Volpiatto <thierry.volpiatto@gmail.com>
+
+;; Author: Thierry Volpiatto <thierry.volpiatto@gmail.com>
+;; Version: 1.0
+;; Keywords: files, convenience
+;; URL: https://github.com/emacs-helm/helm-elscreen
+;; Package-Requires: ((emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -28,7 +34,7 @@
 (declare-function elscreen-goto "ext:elscreen.el" (screen))
 (declare-function elscreen-get-conf-list "ext:elscreen.el" (type))
 
-(defun helm-find-buffer-on-elscreen (candidate)
+(defun helm-elscreen-find-buffer (candidate)
   "Open CANDIDATE buffer in new elscreen.
 If marked buffers, open all in elscreens."
   (helm-require-or-error 'elscreen 'helm-find-buffer-on-elscreen)
@@ -41,13 +47,16 @@ If marked buffers, open all in elscreens."
                           (get-buffer candidate) 'create)))
       (elscreen-goto target-screen))))
 
+;; For compatibility
+(defalias 'helm-find-buffer-on-elscreen 'helm-elscreen-find-buffer)
+
 (defun helm-elscreen-find-file (file)
   "Switch to a elscreen visiting FILE.
 If none already exists, creating one."
   (helm-require-or-error 'elscreen 'helm-elscreen-find-file)
   (elscreen-find-file file))
 
-(defclass helm-source-elscreen (helm-source-sync)
+(defclass helm-elscreen-source (helm-source-sync)
   ((candidates
     :initform
     (lambda ()
@@ -70,7 +79,7 @@ If none already exists, creating one."
                 (elscreen-kill-others)))))
    (migemo :initform t)))
 
-(defclass helm-source-elscreen-history (helm-source-elscreen)
+(defclass helm-elscreen-source-history (helm-elscreen-source)
   ((candidates
     :initform
     (lambda ()
@@ -80,23 +89,23 @@ If none already exists, creating one."
                 collect (cons (format "[%d] %s" screen (cdr (assq screen sname)))
                               screen))))))))
 
-(defvar helm-source-elscreen-list
-  (helm-make-source "ElScreen" 'helm-source-elscreen))
+(defvar helm-elscreen-source-list
+  (helm-make-source "ElScreen" 'helm-elscreen-source))
 
-(defvar helm-source-elscreen-history-list
-  (helm-make-source "ElScreen History" 'helm-source-elscreen-history))
+(defvar helm-elscreen-source-history-list
+  (helm-make-source "ElScreen History" 'helm-elscreen-source-history))
 
 ;;;###autoload
 (defun helm-elscreen ()
   "Preconfigured helm to list elscreen."
   (interactive)
-  (helm-other-buffer 'helm-source-elscreen-list "*Helm ElScreen*"))
+  (helm-other-buffer 'helm-elscreen-source-list "*Helm ElScreen*"))
 
 ;;;###autoload
 (defun helm-elscreen-history ()
   "Preconfigured helm to list elscreen in history order."
   (interactive)
-  (helm-other-buffer 'helm-source-elscreen-history-list "*Helm ElScreen*"))
+  (helm-other-buffer 'helm-elscreen-source-history-list "*Helm ElScreen*"))
 
 (provide 'helm-elscreen)
 


### PR DESCRIPTION
@thierryvolpiatto

I want to add helm-elscreen to https://melpa.org. It needs to follow to [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md). So I fixed errors which were pointed out by checkdoc and package-lint-current-buffer.